### PR TITLE
Remove use of apply

### DIFF
--- a/src/Execute.jl
+++ b/src/Execute.jl
@@ -12,7 +12,7 @@ function evaluate_node(c::Chromosome, node::InteriorNode, context::Vector{BitStr
         evaluate_node(c, c[level, index], context)
     end
     node.active = true
-    return apply(func.func, args)
+    return func.func(args...)
 end
 
 function evaluate_node(c::Chromosome, node::OutputNode, context::Vector{BitString})

--- a/src/Func.jl
+++ b/src/Func.jl
@@ -13,7 +13,7 @@ const OR = Func(|, 2)
 const XOR = Func($, 2)
 const NOT = Func(~, 1)
 const ZERO = Func(() -> convert(BitString, 0), 0, "0")
-const ONE = Func(() -> convert(BitString, ~0), 0, "1")
+const ONE = Func(() -> ~convert(BitString, 0), 0, "1")
 
 function default_funcs()
     return [AND, OR, XOR, NOT, ZERO, ONE]

--- a/src/Goal.jl
+++ b/src/Goal.jl
@@ -67,6 +67,11 @@ end
 ==(g::BasicPackedGoal, h::InterleavedPackedGoal) = error("Cannot compare basic and interleaved goals")
 ==(g::InterleavedPackedGoal, h::BasicPackedGoal) = h == g
 
+# Prints a packed goal in hex by converting it to an unpacked goal.
+function print_goal{T <: PackedGoal}(g::T)
+    print_goal(convert(Goal, g))
+end
+
 # TODO: Do we need a type parameter here? Probably? Maybe?
 function convert(::Type{Goal}, g::BasicPackedGoal)
     temp_ttable = g.truth_table
@@ -170,24 +175,6 @@ end
 #end
 #
 
-
-# prints a packed goal in octal format
-function print_goal_octal(g::GoalPacked)
-    if g.interleaved
-        @printf("(%d, %d, 0o%o interleaved)\n",g.num_inputs,g.num_outputs,g.truth_table)
-    else
-        @printf("(%d, %d, 0o%o non-interleaved)\n",g.num_inputs,g.num_outputs,g.truth_table)
-    end
-end
-
-# prints a packed goal in hex format
-function print_goal_hex(g::GoalPacked)
-    if g.interleaved
-        @printf("(%d, %d, %#X interleaved)\n",g.num_inputs,g.num_outputs,g.truth_table)
-    else
-        @printf("(%d, %d, %#X non-interleaved)\n",g.num_inputs,g.num_outputs,g.truth_table)
-    end
-end
 
 # Composes two goals G and F which must be in packed interleaved format.
 # The number of inputs of G must be equal to the number of outputs of F

--- a/src/Goal.jl
+++ b/src/Goal.jl
@@ -38,11 +38,6 @@ end
 #      All bits of an output are consecutive.
 # interleaved:  All outputs are stored in one BitString.
 #      The bits of outputs are interleaved.  This format is used by the g_compose f function.
-
-# GoalPacked is a goal type where all outputs are "packed" into one BitString.
-# May be non-interleaved or interleaved.
-# The interleaved field should be true if interleaved, false if non-interleaved.
-
 # Packed goals combine all outputs into a single bitstring and, consequently,
 # can only handle functions with an appropriately small number of outputs.
 abstract PackedGoal

--- a/src/Goal.jl
+++ b/src/Goal.jl
@@ -118,6 +118,14 @@ function convert(::Type{BasicPackedGoal}, g::InterleavedPackedGoal)
     return BasicPackedGoal(g.num_inputs, g.num_outputs, ttable)
 end
 
+function convert(::Type{Goal}, g::InterleavedPackedGoal)
+    return convert(Goal, convert(BasicPackedGoal, g))
+end
+
+function convert{N}(::Type{InterleavedPackedGoal}, g::Goal{N})
+    return convert(InterleavedPackedGoal, convert(BasicPackedGoal, g))
+end
+
 # Utility function which returns bitstring mask for one output of the packed representation.
 function output_mask(num_inputs)
     one = convert(BitString, 0x1)

--- a/src/Goal.jl
+++ b/src/Goal.jl
@@ -97,21 +97,22 @@ function convert(::Type{InterleavedPackedGoal}, g::BasicPackedGoal)
     one = convert(BitString, 1)
     p = 2 ^ g.num_inputs
     for j = (p-1):-1:0
-        for k = N:-1:0
+        for k = (g.num_outputs-1):-1:0
             r = g.truth_table >> (k * (p - 1) + j + k)
             ttable = (ttable << 1) $ (r & one)
         end
     end
-    return InterleavedPackedGoal(g.num_inputs, N, ttable)
+    return InterleavedPackedGoal(g.num_inputs, g.num_outputs, ttable)
 end
 
 function convert(::Type{BasicPackedGoal}, g::InterleavedPackedGoal)
-    ttable = convert(BitString,0)
+    ttable = convert(BitString, 0)
     one = convert(BitString, 1)
+    t_g = g.truth_table
     p = 2 ^ g.num_inputs
-    for j in g.num_outputs-1:-1:0
-        for k in p-1:-1:0
-            r = in >> (k * g.num_outputs + j)
+    for j = (g.num_outputs-1):-1:0
+        for k = p-1:-1:0
+            r = t_g >> (k * g.num_outputs + j)
             ttable = (ttable << 1) $ (r & one)
         end
     end
@@ -126,7 +127,8 @@ function convert{N}(::Type{InterleavedPackedGoal}, g::Goal{N})
     return convert(InterleavedPackedGoal, convert(BasicPackedGoal, g))
 end
 
-# Utility function which returns bitstring mask for one output of the packed representation.
+# Utility function which returns bitstring mask for one output of the
+# packed representation.
 function output_mask(num_inputs)
     one = convert(BitString, 0x1)
     mask = one

--- a/src/Goal.jl
+++ b/src/Goal.jl
@@ -69,7 +69,6 @@ function print_goal{T <: PackedGoal}(g::T)
     print_goal(convert(Goal, g))
 end
 
-# TODO: Do we need a type parameter here? Probably? Maybe?
 function convert(::Type{Goal}, g::BasicPackedGoal)
     temp_ttable = g.truth_table
     ttable = Array(BitString, g.num_outputs)

--- a/src/Goal.jl
+++ b/src/Goal.jl
@@ -61,6 +61,8 @@ function =={T <: PackedGoal}(g::T, h::T)
 end
 ==(g::BasicPackedGoal, h::InterleavedPackedGoal) = error("Cannot compare basic and interleaved goals")
 ==(g::InterleavedPackedGoal, h::BasicPackedGoal) = h == g
+=={T <: PackedGoal}(g::Goal, h::T) = error("Cannot compare unpacked and packed goals")
+=={T <: PackedGoal}(g::T, h::Goal) = h == g
 
 # Prints a packed goal in hex by converting it to an unpacked goal.
 function print_goal{T <: PackedGoal}(g::T)

--- a/src/Goal.jl
+++ b/src/Goal.jl
@@ -12,8 +12,8 @@ immutable Goal{N}
 end
 
 Goal{N}(n::Integer, t::NTuple{N, Integer}) = Goal(n, convert(NTuple{N, BitString}, t))
-Goal{N}(n::Integer, b::Vector{BitString}) = Goal(n, ntuple(i -> b[i], length(b)))
-Goal{N}(c::Chromosome, b::Vector{BitString}) = Goal(c.num_inputs, b)
+Goal(n::Integer, b::Vector{BitString}) = Goal(n, ntuple(i -> b[i], length(b)))
+Goal(c::Chromosome, b::Vector{BitString}) = Goal(c.num_inputs, b)
 
 # The equality operator for Goals is true if the number of inputs, number of
 # outputs, and the output truth tables are identical and false otherwise.

--- a/test/Func.jl
+++ b/test/Func.jl
@@ -11,26 +11,26 @@ using Base.Test
 
 # AND
 
-@test apply(AND.func, [ZERO.func(), ZERO.func()]) == ZERO.func()
-@test apply(AND.func, [ONE.func(), ZERO.func()]) == ZERO.func()
-@test apply(AND.func, [ZERO.func(), ONE.func()]) == ZERO.func()
-@test apply(AND.func, [ONE.func(), ONE.func()]) == ONE.func()
+@test AND.func([ZERO.func(), ZERO.func()]...) == ZERO.func()
+@test AND.func([ONE.func(), ZERO.func()]...) == ZERO.func()
+@test AND.func([ZERO.func(), ONE.func()]...) == ZERO.func()
+@test AND.func([ONE.func(), ONE.func()]...) == ONE.func()
 
 # OR
 
-@test apply(OR.func, [ZERO.func(), ZERO.func()]) == ZERO.func()
-@test apply(OR.func, [ONE.func(), ZERO.func()]) == ONE.func()
-@test apply(OR.func, [ZERO.func(), ONE.func()]) == ONE.func()
-@test apply(OR.func, [ONE.func(), ONE.func()]) == ONE.func()
+@test OR.func([ZERO.func(), ZERO.func()]...) == ZERO.func()
+@test OR.func([ONE.func(), ZERO.func()]...) == ONE.func()
+@test OR.func([ZERO.func(), ONE.func()]...) == ONE.func()
+@test OR.func([ONE.func(), ONE.func()]...) == ONE.func()
 
 # XOR
 
-@test apply(XOR.func, [ZERO.func(), ZERO.func()]) == ZERO.func()
-@test apply(XOR.func, [ONE.func(), ZERO.func()]) == ONE.func()
-@test apply(XOR.func, [ZERO.func(), ONE.func()]) == ONE.func()
-@test apply(XOR.func, [ONE.func(), ONE.func()]) == ZERO.func()
+@test XOR.func([ZERO.func(), ZERO.func()]...) == ZERO.func()
+@test XOR.func([ONE.func(), ZERO.func()]...) == ONE.func()
+@test XOR.func([ZERO.func(), ONE.func()]...) == ONE.func()
+@test XOR.func([ONE.func(), ONE.func()]...) == ZERO.func()
 
 # NOT
 
-@test apply(NOT.func, [ZERO.func()]) == ONE.func()
-@test apply(NOT.func, [ONE.func()]) == ZERO.func()
+@test NOT.func([ZERO.func()]...) == ONE.func()
+@test NOT.func([ONE.func()]...) == ZERO.func()

--- a/test/Func.jl
+++ b/test/Func.jl
@@ -7,7 +7,7 @@ using Base.Test
 
 # ONE
 
-@test ONE.func() == convert(BitString, -1)
+@test ONE.func() == typemax(BitString)
 
 # AND
 

--- a/test/Func.jl
+++ b/test/Func.jl
@@ -7,7 +7,7 @@ using Base.Test
 
 # ONE
 
-@test ONE.func() == convert(BitString, 2 ^ 64 - 1)
+@test ONE.func() == convert(BitString, -1)
 
 # AND
 

--- a/test/Goal.jl
+++ b/test/Goal.jl
@@ -19,3 +19,12 @@ g_i = InterleavedPackedGoal(2, 2, 0b00000110)
 @test Goal(2, (0b0000, 0b0000)) != g_u
 @test BasicPackedGoal(2, 2, 0b00000000) != g_p
 @test InterleavedPackedGoal(2, 2, 0b00000000) != g_i
+
+@test_throws ErrorException g_u == g_p
+@test_throws ErrorException g_p == g_u
+@test_throws ErrorException g_p == g_i
+@test_throws ErrorException g_i == g_p
+@test_throws ErrorException g_u == g_i
+@test_throws ErrorException g_i == g_u
+
+# TODO: Add tests for compose()

--- a/test/Goal.jl
+++ b/test/Goal.jl
@@ -1,44 +1,21 @@
 using CGP
 using Base.Test
-include("../src/Goal.jl")
 
-# Tests of functions in src/Goal.jl
-verbose = false
+# Create some goals, these should all be equivalent to one another.
 
-# Test interleave and de_interleave
-# A 3-input 3-output goal packed interleaved goal
-g3int = GoalPacked(3,3,0o51403627,true)
-if verbose print("g3 interleaved: "); print_goal_octal(g3int) end
-# The non-interleaved version of g3int
-g3ni = GoalPacked(3,3,0xA50FC9,false)
-if verbose print("g3 non-interleaved:  "); print_goal_hex(g3ni) end
-@test de_interleave(g3int) == g3ni
-@test interleave(g3ni) == g3int
-@test interleave(de_interleave(g3int)) == g3int
+g_u = Goal(2, (0b0010, 0b0001))
+g_p = BasicPackedGoal(2, 2, 0b00010010)
+g_i = InterleavedPackedGoal(2, 2, 0b00000110)
 
-# Test g_compose_f
-# The inverse of g3int
-g3inv = GoalPacked(3,3,0o02753164,true)
-# The 3-input 3-output identity function in packed interleaved format
-if verbose print("g3 inverse:  "); print_goal_octal(g3inv) end
-ident3 = GoalPacked(3,3,0o76543210,true)
-if verbose print("identity: "); print_goal_octal(ident3) end
-if verbose print("g3 compose h3: ");print_goal_octal(g_compose_f(g3int,ident3)) end
-@test g_compose_f(g3int,g3inv) == ident3
-if verbose print("h3 compose g3: ");print_goal_octal(g_compose_f(ident3,g3int)) end
-@test g_compose_f(g3inv,g3int) == ident3
+@test convert(BasicPackedGoal, g_u) == g_p
+@test convert(InterleavedPackedGoal, g_u) == g_i
 
-# Test pack and unpack
-# The unpacked version of g3ni
-g3unp = Goal(3,3,[0xC9,0x0F,0xA5])  #Note: truth_table components are in the opposite order of what is shown in print_goal
-if verbose print("g3 unpacked:    "); print_goal(g3unp) end
-@test isequal(unpack_goal(g3ni), g3unp)  # Note that == doesn't work.  
-@test pack_goal(g3unp)==g3ni
-@test isequal(unpack_goal(pack_goal(g3unp)),g3unp)
-@test pack_goal(unpack_goal(g3ni))==g3ni
+@test convert(Goal, g_p) == g_u
+@test convert(InterleavedPackedGoal, g_p) == g_i
 
-# test fitness
-#@test fitness(g3unp,g3unp.truth_table)==1.0
-#g3pert = GoalPacked(3,3,0xA40FC9,false)   # differs in one bit from g3ni, should have fitness 0.5
-#if verbose print("g3 perturbed by 1 bit: ");print_goal_hex(g3pert) end
-#@test fitness(unpack_goal(g3pert),g3unp.truth_table)==0.5
+@test convert(Goal, g_i) == g_u
+@test convert(BasicPackedGoal, g_i) == g_p
+
+@test Goal(2, (0b0000, 0b0000)) != g_u
+@test BasicPackedGoal(2, 2, 0b00000000) != g_p
+@test InterleavedPackedGoal(2, 2, 0b00000000) != g_i

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Base.Test
 
 include("Func.jl")
 include("Chromosome.jl")
+include("Goal.jl")
 
 numinputs = 2
 numoutputs = 1


### PR DESCRIPTION
Apply has been deprecated in favor of the `f(args...)` syntax. Remove all uses of `apply`. **Do not merge until `goals-cleanup` is merged into master**.
